### PR TITLE
Add tagger script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+# Set schedule
+name: whippet-application-tagger
+
+on:
+  schedule:
+  - cron: 0 0-23 * * *
+
+jobs:
+  whippet-application-tagger:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: setup
+        uses: actions/checkout@v2
+        env: 
+          GOVPRESS_TOOLS_TOKEN: ${{ secrets.GOVPRESS_TOOLS_TOKEN }}
+
+      - name: Authenticate with GitHub CLI
+        shell: bash       
+        run: |
+          gh auth login --with-token <<< "$GOVPRESS_TOOLS_TOKEN"
+
+      - name: Run tagger script
+        run: |
+          cd $GITHUB_WORKSPACE/main
+          bin/whippet-application-tagger.sh

--- a/.shellcheck.sh
+++ b/.shellcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+FILES="${0} bin/*"
+
+for I in ${FILES}; do
+  echo "Checking ${I}..."
+  perl -pe 's/\{\{.*?\}\}/TEMPLATE_VALUE/g' < "${I}" | shellcheck -
+done
+
+echo OK

--- a/bin/whippet-application-tagger.sh
+++ b/bin/whippet-application-tagger.sh
@@ -9,7 +9,7 @@ REPOS=$(gh api -X GET search/code -f q='filename:whippet.lock org:dxw path:/' --
 for REPO in $REPOS; do
   # skip archived repos
   REPO_IS_ARCHIVED=$(eval "gh api -X GET repos/$REPO -q '.archived'")
-  if [ $REPO_IS_ARCHIVED = true ]; then
+  if [ "$REPO_IS_ARCHIVED" = true ]; then
     continue
   fi
 
@@ -24,7 +24,7 @@ for REPO in $REPOS; do
     else
       NEW_TOPICS=('whippet-app')
     fi
-    printf '%s\n' "${NEW_TOPICS[@]}" | jq -R . | jq -s {"names":.} > input.json
+    printf '%s\n' "${NEW_TOPICS[@]}" | jq -R . | jq -s '{ "names": . }' > input.json
     eval "gh api -X PUT repos/$REPO/topics -H accept:application/vnd.github.mercy-preview+json --input input.json --silent"
     echo "$REPO updated"
     unset NEW_TOPICS

--- a/bin/whippet-application-tagger.sh
+++ b/bin/whippet-application-tagger.sh
@@ -28,9 +28,7 @@ for REPO in $REPOS; do
     eval "gh api -X PUT repos/$REPO/topics -H accept:application/vnd.github.mercy-preview+json --input input.json --silent"
     echo "$REPO updated"
     unset NEW_TOPICS
+    rm input.json
   fi
 
 done
-
-# cleanup
-rm input.json

--- a/bin/whippet-application-tagger.sh
+++ b/bin/whippet-application-tagger.sh
@@ -19,7 +19,11 @@ for REPO in $REPOS; do
   if [[ ! " ${TOPICS[*]} " =~ "whippet-app" ]]; then
     touch input.json
     NEW_TOPICS=${TOPICS}
-    NEW_TOPICS+=('whippet-app')
+    if [ ${#TOPICS} -gt 0 ]; then
+      NEW_TOPICS+=('whippet-app')
+    else
+      NEW_TOPICS=('whippet-app')
+    fi
     printf '%s\n' "${NEW_TOPICS[@]}" | jq -R . | jq -s {"names":.} > input.json
     eval "gh api -X PUT repos/$REPO/topics -H accept:application/vnd.github.mercy-preview+json --input input.json --silent"
     echo "$REPO updated"


### PR DESCRIPTION
This PR:

* Makes some minor fixes to the tagger script (including running shellcheck on it)
* Adds a GitHub action that will run the script once an hour, authenticated as the `dxw-govpress-tools` service user.

I've tested the main tagger script locally, and am confident it behaves as required. I've tried testing the action locally using [act](https://github.com/nektos/act), but unfortunately none of the available images include GitHub CLI (unlike the `ubuntu-latest` environment on GitHub itself, which does: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#cli-tools). So I think the best bet at this point is just to get this merged and see if the action completes successfully at the next scheduled time (once an hour). If it doesn't, it should just fail without making any changes.