### PR TITLE
Add ability to test full action locally with act

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: install GH CLI for local testing
-        if: ${{ env.GITHUB_ACTIONS != true }}
+        if: ${{ env.ACT }}
         run: |
           curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,14 @@ jobs:
       - name: setup
         uses: actions/checkout@v2
 
+      - name: install GH CLI for local testing
+        if: ${{ env.GITHUB_ACTIONS != true }}
+        run: |
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt update
+          sudo apt install gh 
+
       - name: Authenticate with GitHub CLI
         shell: bash       
         run: |

--- a/README.md
+++ b/README.md
@@ -15,3 +15,10 @@ gh auth login
 ...
 bin/whippet-application-tagger.sh
 ```
+
+Or you can run the action as a whole using (act)[https://github.com/nektos/act]:
+
+* Install act: `brew install act`
+* Run the action: `act -j whippet-application-tagger -s GOVPRESS_TOOLS_TOKEN=[a token that has repo and org access]`
+
+Note: this will actually run the action against live data, so will add the topic to any relevant repos that don't already have it.


### PR DESCRIPTION
The docker images that act uses to test GitHub actions locally don't
include GitHub CLI (unlike the virtual environments that GitHub actions
actually run in), so it wasn't previously possible to test the action
locally.

Now it is, as we're testing for the presence of the GITHUB_ACTIONS
environment variable, that all GitHub actions set to true by default
(https://docs.github.com/en/actions/reference/environment-variables).

If that variable isn't present, we install GitHub CLI, so it's available
locally for running the rest of the action.