### PR TITLE
Only run the action 0800-1800 UTC time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: whippet-application-tagger
 
 on:
   schedule:
-  - cron: 0 8-18 * * *
+  - cron: 0 8-18 * * MON-FRI
 
 jobs:
   whippet-application-tagger:


### PR DESCRIPTION
We've had to make this repo private to prevent GitHub auto-disabling the
workflow after 60 days of repo inactivity.

That means we'll be paying for the minutes when we run the action. It's
pretty quick, so that's not a massive cost, but we can balance it a bit
by only running it during working hours on working days.