### PR TITLE
Use keep-workflow-alive to ensure scheduled workflow stays active

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,3 +29,10 @@ jobs:
       - name: Run tagger script
         run: |
           bin/whippet-application-tagger.sh
+      
+      - name: Keep workflow alive
+        uses: dxw/keepalive-workflow@master
+        with:
+          commit_message: Automated commit by Keepalive Workflow to keep the repository active [skip ci]
+          committer_username: dxw-govpress-tools
+          committer_email: team+govpress-tools@govpress.com


### PR DESCRIPTION
GitHub automatically disables scheduled workflows on public repos that
have had no activity for 60 days. It currently defines "activity" as git
activity on the default branch.

This causes an issue in this repo, as we need the task to run
indefinitely, so that GovPress Tools always reports back correctly.

This commit adds dxw's fork of the keepalive-workflow action to address
this problem. This action adds an empty commit to the default branch
every 50 days, if there has been no other activity in the meantime. It's
not an ideal way of solving the problem, but it's better than the
workflow repeatedly deactivating, which is the only other option at the
moment.

We've implemented this approach successfully on other dxw repos, e.g.
dxw/golden-retriever#126