### PR TITLE
Replace the keepalive workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,13 +30,6 @@ jobs:
         run: |
           bin/whippet-application-tagger.sh
 
-      - name: Keep workflow alive
-        uses: gautamkrishnar/keepalive-workflow@1.1.0
-        with:
-          commit_message: Automated commit by Keepalive Workflow to keep the repository active [skip ci]
-          committer_username: dxw-govpress-tools
-          committer_email: team+govpress-tools@govpress.com
-
       - name: Alert Slack if failure
         if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.23.0
@@ -45,3 +38,11 @@ jobs:
           slack-message: "Our Whippet Application Tagger has failed. Check the workflow history for more information: https://github.com/dxw/whippet-application-tagger/blob/main/.github/workflows/main.yml, and see the documentation for possible causes: https://github.com/dxw/govpress-tools/blob/main/documentation/scheduled_tasks.md#investigating-failures"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c


### PR DESCRIPTION
Scheduled workflows in this repository tend to timeout, which means that we need a keepalive workflow to ensure that any operations that run over the whole plugin library run to completion.

The workflow we used before is this:

https://github.com/gautamkrishnar/keepalive-workflow

and currently has a notice on the repo page:

    Access to this repository has been disabled by GitHub Staff
    due to a violation of GitHub's terms of service. If you are
    the owner of the repository, you may reach out to GitHub
    Support for more information.

To ensure that the actions do not fail, this commit replaces that workflow with this one:

    https://github.com/liskin/gh-workflow-keepalive/

Pinned to the commit we reviewed, which was:

    f72ff1a1336129f29bf0166c0fd0ca6cf1bcb38c